### PR TITLE
Organize project directories and add initial documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.env
+notebooks/*checkpoint*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # patent
 
+Patent analysis snippets for collecting data and comparing claims using
+public APIs.
+
+## Repository structure
+
+- `src/` – Python modules for data collection and claim comparison.
+- `notebooks/` – Demonstration notebooks.
+- `docs/` – Additional documentation.
+
+
 
 いいですね。「OPS（EPO）／The Lens APIで“機械化→要点サマリ＋クレーム比較”」の“実務でそのまま使える”ミニ事例を3つ出します。すべてWindows10＋VSCode＋Python前提、公開API仕様に沿ったコード断片つきです。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This directory holds additional guides and notes for the patent analysis
+examples.
+
+## Project structure
+
+- `src/` – Python modules implementing data collection and claim comparison.
+- `notebooks/` – Example notebooks demonstrating patent landscape studies.

--- a/notebooks/PLS_demo.ipynb
+++ b/notebooks/PLS_demo.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Patent Landscape Demo\n",
+    "This notebook demonstrates basic usage of the patent analysis scripts."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/claim_compare.py
+++ b/src/claim_compare.py
@@ -1,0 +1,54 @@
+"""Utilities for comparing patent claims.
+
+The functions in this module help build a simple claim chart and compute
+rough similarity scores using token-based matching from
+:mod:`rapidfuzz`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+from rapidfuzz import fuzz
+
+from .collect_lens import split_claim_elements
+
+
+def normalize_term(s: str) -> str:
+    """Normalize terms for comparison."""
+    import re
+
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9\s\-_/]", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def claim_elements(claim_text: str) -> List[str]:
+    """Split a claim into normalized elements."""
+    return [normalize_term(t) for t in split_claim_elements(claim_text)]
+
+
+def chart_and_diff(my_claim: str, prior_claims: List[str]) -> List[Dict]:
+    """Compare *my_claim* against *prior_claims*.
+
+    Returns a list of dictionaries sorted by similarity containing
+    overlapping, missing and extra elements for each prior claim.
+    """
+    my_elems: Set[str] = set(claim_elements(my_claim))
+    rows = []
+    for pc in prior_claims:
+        pe = set(claim_elements(pc))
+        overlap = my_elems & pe
+        missing = my_elems - pe
+        extra = pe - my_elems
+        sim = fuzz.token_set_ratio(" ".join(my_elems), " ".join(pe))
+        rows.append(
+            {
+                "sim": sim,
+                "overlap": list(overlap)[:10],
+                "missing": list(missing)[:10],
+                "extra": list(extra)[:10],
+            }
+        )
+    return sorted(rows, key=lambda x: x["sim"], reverse=True)[:5]

--- a/src/collect_lens.py
+++ b/src/collect_lens.py
@@ -1,0 +1,102 @@
+"""Utilities for retrieving patent data from The Lens API.
+
+This module provides helper functions to query the Lens patent API and
+return simplified patent information. An access token is expected in the
+``LENS_API_TOKEN`` environment variable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict
+
+import requests
+from rapidfuzz import fuzz
+
+LENS_ENDPOINT = "https://api.lens.org/patent/search"
+
+
+def split_claim_elements(text: str) -> List[str]:
+    """Split a claim into coarse elements using simple heuristics."""
+    import re
+
+    seps = r"(;|, and |, or | comprising | wherein | wherein the | including )"
+    parts = [
+        p.strip(" ,;.")
+        for p in re.split(seps, text, flags=re.I)
+        if p and not re.match(seps, p, re.I)
+    ]
+    return [p for p in parts if len(p.split()) >= 3]
+
+
+def first_independent_claim(claims: List[str]) -> str:
+    """Return the first independent claim from a list of claim strings."""
+    import re
+
+    for c in claims:
+        if re.search(r"independent|claim\s*1", c, flags=re.I) or (
+            "dependent" not in c.lower()
+        ):
+            return c
+    return claims[0] if claims else ""
+
+
+def similarity(a: str, b: str) -> int:
+    """Return a rough similarity score between two texts."""
+    return fuzz.token_set_ratio(a, b)
+
+
+def search_lens(query: str, size: int = 50, my_invention: str = "") -> List[Dict]:
+    """Query The Lens API and return simplified patent records.
+
+    Parameters
+    ----------
+    query:
+        Search expression supported by Lens.
+    size:
+        Number of records to request.
+    my_invention:
+        Optional description of the user's invention. If supplied, a
+        similarity score against each independent claim is computed.
+    """
+    payload = {
+        "query": query,
+        "size": size,
+        "include": [
+            "lens_id",
+            "title",
+            "abstract",
+            "claims",
+            "applicants",
+            "cpc",
+            "date_published",
+        ],
+    }
+    resp = requests.post(
+        LENS_ENDPOINT,
+        headers={
+            "Authorization": f"Bearer {os.getenv('LENS_API_TOKEN')}",
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(payload),
+    ).json()
+
+    docs = resp.get("data", [])
+    table = []
+    for d in docs:
+        claims = d.get("claims", []) or []
+        ic = first_independent_claim(claims)
+        elems = split_claim_elements(ic)
+        score = similarity(my_invention, ic) if my_invention else 0
+        table.append(
+            {
+                "lens_id": d["lens_id"],
+                "title": d.get("title", "")[:80],
+                "date": d.get("date_published", ""),
+                "score": score,
+                "elements": elems[:8],
+            }
+        )
+
+    return sorted(table, key=lambda x: x["score"], reverse=True)

--- a/src/collect_ops.py
+++ b/src/collect_ops.py
@@ -1,0 +1,48 @@
+"""Retrieve patent documents from the EPO OPS service.
+
+The :mod:`patent_client` package is used to access EPO's OPS API. API
+credentials are read from ``PATENT_CLIENT_EPO_API_KEY`` and
+``PATENT_CLIENT_EPO_SECRET`` environment variables.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+from patent_client import PatentSearchClient
+
+
+def parse_conditions(text: str) -> Dict[str, List]:
+    """Extract simple process conditions from claim text."""
+    import re
+
+    o2 = re.findall(r"(oxygen|O2)[^0-9]{0,10}(\d+\.?\d*)\s*(Pa|%|sccm)", text, flags=re.I)
+    temp = re.findall(r"(\d{2,3})\s*°?C", text)
+    layers = re.findall(r"(multi[-\s]?layer|(\d+)\s*layers?)", text, flags=re.I)
+    return {"o2": o2, "temp_C": temp, "layers": layers}
+
+
+def search_ops(query: str, size: int = 50) -> List[Dict]:
+    """Search the OPS API and return a simplified landscape table."""
+    client = PatentSearchClient(
+        ops_api_key=os.getenv("PATENT_CLIENT_EPO_API_KEY"),
+        ops_api_secret=os.getenv("PATENT_CLIENT_EPO_SECRET"),
+    )
+    results = client.search(query, size=size)
+
+    landscape = []
+    for r in results:
+        fulltext = r.get_fulltext() or ""
+        claims = r.get_claims() or []
+        ic = claims[0] if claims else fulltext[:2000]
+        cond = parse_conditions(ic)
+        landscape.append(
+            {
+                "pub": r.publication_number,
+                "title": r.title[:80],
+                "o2/temp/layers": cond,
+                "cpc": r.cpc_classes[:5],
+            }
+        )
+    return landscape


### PR DESCRIPTION
## Summary
- scaffold `src` module with scripts for Lens and OPS API queries and claim comparison
- add `docs` and `notebooks` directories with a demo notebook and documentation
- revise README to outline new repository structure and ignore common artifacts

## Testing
- `python -m py_compile src/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7b37d36ac8325b5cd954f86974a62